### PR TITLE
Fix atom.syntax deprecated method.

### DIFF
--- a/lib/atom-xsltransform-view.coffee
+++ b/lib/atom-xsltransform-view.coffee
@@ -52,7 +52,7 @@ class AtomXsltransformView extends View
     @close()
 
     view = new TextEditorView()
-    xmlGrammar = atom.syntax.grammarForScopeName("text.xml")
+    xmlGrammar = atom.grammars.grammarsByScopeName["text.xml"]
     view.getModel().setGrammar(xmlGrammar)
 
     panes = atom.workspace.getPanes()


### PR DESCRIPTION
Fixes #1 and #2 

Resolves deprecations ready for Atom V1.0.
